### PR TITLE
feat/added auth middleware and unittest

### DIFF
--- a/backend/api/main_test.go
+++ b/backend/api/main_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	db "github.com/project-available/available.git/db/sqlc"
+	"github.com/project-available/available.git/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestServer(t *testing.T, store db.Store) *Server {
+	config := utils.Config{
+		TokenSymmetricKey:   utils.RandomString(32),
+		AccessTokenDuration: time.Minute,
+	}
+	server, err := NewServer(config, store)
+	require.NoError(t, err)
+
+	return server
+}
+
+func TestMain(m *testing.M) {
+	gin.SetMode(gin.TestMode)
+
+	os.Exit(m.Run())
+}

--- a/backend/api/middleware.go
+++ b/backend/api/middleware.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/project-available/available.git/token"
+)
+
+const (
+	authorizationHeaderKey  = "authorization"
+	authorizationTypeBearer = "bearer"
+	authorizationPayloadKey = "authorization_payload"
+)
+
+func authMiddleWare(tokenMaker token.Maker) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		authorizationHeader := ctx.GetHeader(authorizationHeaderKey)
+		if len(authorizationHeader) == 0 {
+			err := errors.New("authorization header is not provided")
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, errorMessage(err))
+			return
+		}
+
+		fields := strings.Fields(authorizationHeader)
+		if len(fields) < 2 {
+			err := errors.New("invalid authorization header format")
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, errorMessage(err))
+			return
+		}
+
+		authorizationType := strings.ToLower(fields[0])
+		if authorizationType != authorizationTypeBearer {
+			err := errors.New("unsupported authorization type")
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, errorMessage(err))
+			return
+		}
+
+		accessToken := fields[1]
+		payload, err := tokenMaker.VerifyToken(accessToken)
+		if err != nil {
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, errorMessage(err))
+			return
+		}
+
+		ctx.Set(authorizationPayloadKey, payload)
+		ctx.Next()
+	}
+}

--- a/backend/api/middleware_test.go
+++ b/backend/api/middleware_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/project-available/available.git/token"
+	"github.com/stretchr/testify/require"
+)
+
+// addAuthorization adds access_token to request's header
+func addAuthorization(
+	t *testing.T,
+	request *http.Request,
+	tokenMaker token.Maker,
+	authorizationType string,
+	username string,
+	duration time.Duration,
+) {
+	token, err := tokenMaker.CreateToken(username, duration)
+	require.NoError(t, err)
+
+	authorizationHeader := fmt.Sprintf("%s %s", authorizationType, token)
+	request.Header.Set(authorizationHeaderKey, authorizationHeader)
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	testcases := []struct {
+		name          string
+		setupAuth     func(t *testing.T, request *http.Request, tokenMaker token.Maker)
+		checkResponse func(t *testing.T, recorder *httptest.ResponseRecorder)
+	}{
+		{
+			name: "OK",
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, authorizationTypeBearer, "user", time.Minute)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, recorder.Code)
+			},
+		},
+		{
+			name: "NoAuthorization",
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			name: "UnsupportedAuthorizationType",
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, "unsupported", "user", time.Minute)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			name: "InvalidAuthorizationFormat",
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				invalidAuthorizationHeader := fmt.Sprintf("%s %s", authorizationTypeBearer, "")
+				request.Header.Set(authorizationHeaderKey, invalidAuthorizationHeader)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			name: "InvalidAuthorizationToken",
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				invalidAuthorizationToken := fmt.Sprintf("%s %s", authorizationTypeBearer, "faketoken")
+				request.Header.Set(authorizationHeaderKey, invalidAuthorizationToken)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			name: "ExpiredAuthorizationToken",
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, authorizationTypeBearer, "user", -time.Minute)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newTestServer(t, nil)
+			authPath := "/auth"
+
+			server.router.GET(
+				authPath,
+				authMiddleWare(server.tokenMaker),
+				func(ctx *gin.Context) {
+					ctx.JSON(http.StatusOK, gin.H{})
+				},
+			)
+
+			recorder := httptest.NewRecorder()
+			request, err := http.NewRequest(http.MethodGet, authPath, nil)
+			require.NoError(t, err)
+
+			tc.setupAuth(t, request, server.tokenMaker)
+			server.router.ServeHTTP(recorder, request)
+			tc.checkResponse(t, recorder)
+		})
+	}
+}

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -35,27 +35,29 @@ func NewServer(config utils.Config, store db.Store) (*Server, error) {
 
 func (server *Server) setupRouter() {
 	router := gin.Default()
-	//account
-	router.POST("/accounts", server.createAccount)
-	router.GET("/accounts/:student_id", server.getAccount)
-	router.GET("/accounts", server.listAccounts)
-	router.PUT("/accounts/:id", server.updateAccount)
-	router.DELETE("/accounts/:student_id", server.deleteAccount)
 
-	//authentication
+	router.POST("/accounts", server.createAccount)
 	router.POST("/accounts/login", server.loginAccount)
 
-	//booking
-	router.POST("/bookings", server.createBooking)
-	router.GET("/bookings/:account_id", server.getBookingOfAccount)
-	router.GET("/bookings", server.listBookings)
-	router.POST("/bookings/update/:id", server.updateBooking)
-
-	//room
-	router.POST("/rooms", server.createRoom)
 	router.GET("/rooms", server.listRooms)
-	router.POST("/rooms/update/:id", server.updateRoom)
-	router.DELETE("/rooms/delete/:id", server.deleteRoom)
+
+	router.GET("/bookings", server.listBookings)
+
+	authRoutes := router.Group("/").Use(authMiddleWare(server.tokenMaker))
+
+	authRoutes.GET("/accounts/:student_id", server.getAccount)
+	authRoutes.GET("/accounts", server.listAccounts)
+	authRoutes.PUT("/accounts/:id", server.updateAccount)
+	authRoutes.DELETE("/accounts/:student_id", server.deleteAccount)
+
+	authRoutes.GET("/bookings/:account_id", server.getBookingOfAccount)
+	authRoutes.POST("/bookings/update/:id", server.updateBooking)
+	authRoutes.POST("/bookings", server.createBooking)
+
+	authRoutes.POST("/rooms", server.createRoom)
+	authRoutes.POST("/rooms/update/:id", server.updateRoom)
+	authRoutes.DELETE("/rooms/delete/:id", server.deleteRoom)
+
 	server.router = router
 }
 


### PR DESCRIPTION
Require an access-token to use these endpoints

GET("/accounts/:student_id")
GET("/accounts")
PUT("/accounts/:id")
DELETE("/accounts/:student_id")

GET("/bookings/:account_id")
POST("/bookings/update/:id")
POST("/bookings")

POST("/rooms")
POST("/rooms/update/:id")
DELETE("/rooms/delete/:id")